### PR TITLE
feat : Remove Images Associated with Stopped Containers (Issue : #4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
+# binary for linux machine
 /dockclean
+# binary for windows machine
+/dockclean.exe 
+# Dockerfile that can be used for testing
+/Dockerfile

--- a/cmd/cleaner/main.go
+++ b/cmd/cleaner/main.go
@@ -1,30 +1,11 @@
 package main
 
 import (
-	"flag"
 	"log"
 
-	"github.com/mmuazam98/dockclean/pkg/docker"
+	"github.com/mmuazam98/dockclean/internal/docker"
+	"github.com/mmuazam98/dockclean/pkg/utils"
 )
-
-func parseFlag(dc docker.DockerClient) {
-
-	dryRun := flag.Bool("dry-run", false, "List unused Docker images without deleting them")
-	removeStopped := flag.Bool("remove-stopped", false, "Remove Images Associated with Stopped Containers")
-
-	flag.Parse()
-
-	switch {
-
-	case *dryRun:
-		dc.PrintUnusedImages()
-	case *removeStopped:
-		dc.CleanupStoppedContainerImages()
-	default:
-		dc.RemoveUnusedImages()
-
-	}
-}
 
 func main() {
 
@@ -35,5 +16,15 @@ func main() {
 		log.Fatalf("Error initializing docker client : %v", err)
 	}
 
-	parseFlag(dc)
+	f := utils.ParseFlags()
+
+	switch {
+	case f.DryRun:
+		dc.PrintUnusedImages()
+	case f.RemoveStopped:
+		dc.CleanupStoppedContainerImages()
+	default:
+		dc.RemoveUnusedImages()
+	}
+
 }

--- a/cmd/cleaner/main.go
+++ b/cmd/cleaner/main.go
@@ -4,38 +4,36 @@ import (
 	"flag"
 	"log"
 
-	"github.com/docker/docker/client"
 	"github.com/mmuazam98/dockclean/pkg/docker"
 )
 
-func parseFlag(cli *client.Client) {
+func parseFlag(dc docker.DockerClient) {
+
 	dryRun := flag.Bool("dry-run", false, "List unused Docker images without deleting them")
 	removeStopped := flag.Bool("remove-stopped", false, "Remove Images Associated with Stopped Containers")
 
 	flag.Parse()
 
-	if *dryRun {
-		docker.PrintUnusedImages(cli)
-	} else if *removeStopped {
-		docker.CleanupStoppedContainerImages(cli)
-	} else {
-		docker.RemoveUnusedImages(cli)
+	switch {
+
+	case *dryRun:
+		dc.PrintUnusedImages()
+	case *removeStopped:
+		dc.CleanupStoppedContainerImages()
+	default:
+		dc.RemoveUnusedImages()
+
 	}
 }
 
 func main() {
-	cli, err := initDockerClient()
+
+	var dc docker.DockerClient
+
+	err := dc.InitDockerClient()
 	if err != nil {
-		log.Fatalf("Failed to initialize Docker client: %v", err)
+		log.Fatalf("Error initializing docker client : %v", err)
 	}
 
-	parseFlag(cli)
-}
-
-func initDockerClient() (*client.Client, error) {
-	cli, err := docker.NewDockerClient()
-	if err != nil {
-		return nil, err
-	}
-	return cli, nil
+	parseFlag(dc)
 }

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -1,0 +1,22 @@
+package docker
+
+import (
+	"context"
+
+	"github.com/docker/docker/client"
+)
+
+type DockerClient struct {
+	CLI *client.Client
+}
+
+// InitDockerClient initializes a new Docker client
+func (d *DockerClient) InitDockerClient() error {
+	cli, err := client.NewClientWithOpts(client.FromEnv)
+	if err != nil {
+		return nil
+	}
+	cli.NegotiateAPIVersion(context.Background())
+	d.CLI = cli
+	return nil
+}

--- a/internal/docker/images.go
+++ b/internal/docker/images.go
@@ -1,0 +1,70 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/docker/docker/api/types/image"
+)
+
+// ListUnusedImages returns a list of unused Docker images
+func (d *DockerClient) ListUnusedImages() ([]image.Summary, error) {
+
+	images, err := d.CLI.ImageList(context.Background(), image.ListOptions{All: true})
+	if err != nil {
+		return nil, err
+	}
+
+	var unusedImages []image.Summary
+	for _, image := range images {
+		// Filter images without RepoTags (untagged or unused images)
+		if len(image.RepoTags) == 0 {
+			unusedImages = append(unusedImages, image)
+		}
+	}
+
+	if len(unusedImages) > 0 {
+		fmt.Printf("Found %d unused images\n", len(unusedImages))
+	}
+	return unusedImages, nil
+}
+
+// PrintUnusedImages lists the images that would be removed (Dry Run)
+func (d *DockerClient) PrintUnusedImages() {
+
+	images, err := d.ListUnusedImages()
+	if err != nil {
+		log.Fatalf("Error listing images: %v", err)
+	}
+
+	if len(images) == 0 {
+		fmt.Println("No unused images found.")
+		return
+	}
+
+	fmt.Println("The following images would be removed:")
+	for _, image := range images {
+		fmt.Printf("ID: %s, Created: %d\n", image.ID, image.Created)
+	}
+}
+
+// RemoveUnusedImages deletes unused Docker images
+func (d *DockerClient) RemoveUnusedImages() {
+
+	images, err := d.ListUnusedImages()
+	if err != nil {
+		log.Fatalf("Error listing images: %v", err)
+	}
+
+	opts := image.RemoveOptions{Force: true}
+
+	for _, image := range images {
+		_, err := d.CLI.ImageRemove(context.Background(), image.ID, opts)
+		if err != nil {
+			log.Printf("Failed to remove image %s: %v", image.ID, err)
+		} else {
+			log.Printf("Successfully removed image %s", image.ID)
+		}
+	}
+}

--- a/pkg/docker/cleaner.go
+++ b/pkg/docker/cleaner.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
 )
@@ -17,6 +18,81 @@ func NewDockerClient() (*client.Client, error) {
 	}
 	cli.NegotiateAPIVersion(context.Background())
 	return cli, nil
+}
+
+// CleanupStoppedContainerImages removes images associated with stopped containers
+func CleanupStoppedContainerImages(cli *client.Client) {
+
+	const (
+		ImageStateUnreferenced = -1
+		ImageStateExited       = 0
+		ImageStateRunning      = 1
+	)
+
+	// List all images
+	images, err := cli.ImageList(context.Background(), image.ListOptions{})
+	if err != nil {
+		log.Fatalf("Error listing images: %v", err)
+	}
+
+	imagesForCleanup := make(map[string]int8)
+
+	// -1 : not referenced
+	// 0  : exited
+	// 1  : other state
+	for _, image := range images {
+		imagesForCleanup[image.ID] = ImageStateUnreferenced // Marking all images as -1, currently not referenced
+	}
+
+	// List all containers
+	containers, err := cli.ContainerList(context.Background(), container.ListOptions{All: true})
+	if err != nil {
+		panic(err)
+	}
+
+	// Create a map to hold containers associated with images to be deleted
+	containersToRemove := make(map[string]string) // container ID -> image ID
+
+	// Unreferenced containers are not affected so can identify using -1
+	// If all are exited, the state will update once to 0 and won't be affected any later
+	// Even if one of the container is not exited, it will be updated to one
+	for _, container := range containers {
+		containerState, containerImageID := container.State, container.ImageID
+
+		if containerState == "exited" && imagesForCleanup[containerImageID] != ImageStateRunning {
+
+			// Mark image as exited if no running containers are using it, otherwise mark it as running
+			imagesForCleanup[containerImageID] = ImageStateExited
+			containersToRemove[container.ID] = containerImageID // Track the container for later removal
+		} else {
+			imagesForCleanup[containerImageID] = ImageStateRunning
+		}
+	}
+
+	// Remove all the images for those whose all of the associated containers are stopped, and not just one
+	opts := image.RemoveOptions{Force: true}
+
+	for imageId, removalState := range imagesForCleanup {
+		if removalState == ImageStateExited {
+			_, err := cli.ImageRemove(context.Background(), imageId, opts)
+			if err != nil {
+				log.Printf("Failed to remove image %s: %v", imageId, err)
+			} else {
+				log.Printf("Successfully removed image %s", imageId)
+				// Remove associated containers only if the image was successfully deleted
+				for containerID, imageID := range containersToRemove {
+					if imageID == imageId {
+						if err := cli.ContainerRemove(context.Background(), containerID, container.RemoveOptions{Force: true}); err != nil {
+							log.Printf("Failed to remove stopped container %s: %v", containerID, err)
+						} else {
+							log.Printf("Successfully removed stopped container %s", containerID)
+						}
+					}
+				}
+			}
+		}
+	}
+
 }
 
 // ListUnusedImages returns a list of unused Docker images
@@ -41,7 +117,13 @@ func ListUnusedImages(cli *client.Client) ([]image.Summary, error) {
 }
 
 // RemoveUnusedImages deletes unused Docker images
-func RemoveUnusedImages(cli *client.Client, images []image.Summary) {
+func RemoveUnusedImages(cli *client.Client) {
+
+	images, err := ListUnusedImages(cli)
+	if err != nil {
+		log.Fatalf("Error listing images: %v", err)
+	}
+
 	opts := image.RemoveOptions{Force: true}
 
 	for _, image := range images {
@@ -55,7 +137,13 @@ func RemoveUnusedImages(cli *client.Client, images []image.Summary) {
 }
 
 // PrintUnusedImages lists the images that would be removed (Dry Run)
-func PrintUnusedImages(images []image.Summary) {
+func PrintUnusedImages(cli *client.Client) {
+
+	images, err := ListUnusedImages(cli)
+	if err != nil {
+		log.Fatalf("Error listing images: %v", err)
+	}
+
 	if len(images) == 0 {
 		fmt.Println("No unused images found.")
 		return

--- a/pkg/utils/flags.go
+++ b/pkg/utils/flags.go
@@ -1,0 +1,16 @@
+package utils
+
+import "flag"
+
+type Flags struct {
+	DryRun        bool
+	RemoveStopped bool
+}
+
+func ParseFlags() *Flags {
+	f := &Flags{}
+	flag.BoolVar(&f.DryRun, "dry-run", false, "List unused Docker images without deleting them")
+	flag.BoolVar(&f.RemoveStopped, "remove-stopped", false, "Remove Images Associated with Stopped Containers")
+	flag.Parse()
+	return f
+}


### PR DESCRIPTION
Code Updates

- [x] Main functionality : **CleanupStoppedContainerImages(cli *client.Client)**
- [x] Additional Fix 01   : Updated .gitignore, made it more generalized
- [x] Additional Fix 02   : Updated the structure of cmd/cleaner/main.go, made it more consistent


## Implementation Details

The function first lists all Docker images and initializes them as "unreferenced". It then lists all containers and updates the state of each image based on its associated containers:

- If all associated containers are stopped, the image is marked for potential removal.
- If any associated container is running, the image is marked as in use.

Images marked for potential removal are then removed using the Docker API. After successful image removal, associated stopped containers are also removed.

## Purpose of This Functionality

This ensures that even though the images are deleted, the associated stopped containers are not left behind. If the stopped containers remain without their associated images, it could cause errors during future runs of the --remove-stopped command, such as "the associated image of the stopped container is not present." This functionality prevents those errors by cleaning up both the images and their stopped containers together.

Tested Example
![image](https://github.com/user-attachments/assets/de9a38fa-625e-4053-b4af-6138661f6cc9)

