### PR TITLE
Completed Feature: Image Size Threshold (Issue : #3) 

### DIFF
--- a/cmd/cleaner/main.go
+++ b/cmd/cleaner/main.go
@@ -23,6 +23,8 @@ func main() {
 		dc.PrintUnusedImages()
 	case f.RemoveStopped:
 		dc.CleanupStoppedContainerImages()
+	case f.VerboseMode:
+		dc.VerboseModeCleanup()
 	default:
 		dc.RemoveUnusedImages()
 	}

--- a/cmd/cleaner/main.go
+++ b/cmd/cleaner/main.go
@@ -25,6 +25,12 @@ func main() {
 		dc.CleanupStoppedContainerImages()
 	case f.VerboseMode:
 		dc.VerboseModeCleanup()
+	case f.SizeLimit.Value >= 0:
+		var unit string = f.GetSizeUnit()
+		if unit == "" {
+			log.Fatalf("Please specify a size unit (B, KB, MB, or GB)")
+		}
+		dc.RemoveExceedSizeLimit(f.SizeLimit.Value, unit)
 	default:
 		dc.RemoveUnusedImages()
 	}

--- a/internal/docker/containers.go
+++ b/internal/docker/containers.go
@@ -9,7 +9,7 @@ import (
 )
 
 // CleanupStoppedContainerImages removes images associated with stopped containers
-func (d *DockerClient) CleanupStoppedContainerImages() {
+func (d *DockerClient) CleanupStoppedContainerImages() error {
 
 	const (
 		ImageStateUnreferenced = -1
@@ -20,7 +20,8 @@ func (d *DockerClient) CleanupStoppedContainerImages() {
 	// List all images
 	images, err := d.CLI.ImageList(context.Background(), image.ListOptions{})
 	if err != nil {
-		log.Fatalf("Error listing images: %v", err)
+		log.Printf("Error listing images: %v", err)
+		return err
 	}
 
 	imagesForCleanup := make(map[string]int8)
@@ -81,4 +82,5 @@ func (d *DockerClient) CleanupStoppedContainerImages() {
 		}
 	}
 
+	return nil
 }

--- a/internal/docker/images.go
+++ b/internal/docker/images.go
@@ -49,6 +49,53 @@ func (d *DockerClient) PrintUnusedImages() {
 	}
 }
 
+// VerboseModeCleanup gives more details while doing the cleanup of unused images
+func (d *DockerClient) VerboseModeCleanup() {
+
+	images, err := d.ListUnusedImages()
+	if err != nil {
+		log.Fatalf("Error listing images: %v", err)
+	}
+
+	opts := image.RemoveOptions{Force: true}
+
+	if len(images) == 0 {
+		log.Println("No unused images found")
+		return
+	}
+
+	log.Printf("Found %d unused images. Starting removal in verbose mode...\n", len(images))
+
+	// Print table header
+	fmt.Println("---------------------------------------------------------------")
+	fmt.Printf("%-15s %-12s %-15s %s\n", "ID", "Size (bytes)", "Created (Unix)", "Labels")
+	fmt.Println("---------------------------------------------------------------")
+
+	// Iterate over each unused image and attempt removal
+	for _, image := range images {
+		// Remove the image
+		_, err := d.CLI.ImageRemove(context.Background(), image.ID, opts)
+		if err != nil {
+			log.Printf("Failed to remove image %s: %v\n", image.ID, err)
+		} else {
+			// Print image information in a table-like format
+			fmt.Printf("%-15s %-12d %-15d ", image.ID[:12], image.Size, image.Created)
+
+			// Display labels
+			if len(image.Labels) > 0 {
+				labelStr := ""
+				for key, value := range image.Labels {
+					labelStr += fmt.Sprintf("%s:%s, ", key, value)
+				}
+				fmt.Println(labelStr[:len(labelStr)-2]) // Remove the last comma
+			} else {
+				fmt.Println("No labels")
+			}
+		}
+	}
+
+}
+
 // RemoveUnusedImages deletes unused Docker images
 func (d *DockerClient) RemoveUnusedImages() {
 
@@ -65,6 +112,7 @@ func (d *DockerClient) RemoveUnusedImages() {
 			log.Printf("Failed to remove image %s: %v", image.ID, err)
 		} else {
 			log.Printf("Successfully removed image %s", image.ID)
+
 		}
 	}
 }

--- a/internal/docker/utils.go
+++ b/internal/docker/utils.go
@@ -1,0 +1,59 @@
+package docker
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Helper function to truncate docker image ID with ellipsis
+func FormatDockerImageID(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}
+
+// Helper function to converts bytes to human-readable format
+func FormatSize(bytes int64) string {
+	const unit = 1024.0
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	div, exp := int64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}
+
+// Helper function used to format the docker image labels Key Value Pairs
+func FormatLabels(labels map[string]string) string {
+	if len(labels) == 0 {
+		return "No Labels Found"
+	}
+
+	var labelStore []string
+	for labelKey, labelValue := range labels {
+		// Handling empty values
+		if labelValue == "" {
+			labelStore = append(labelStore, labelKey)
+			continue
+		}
+		labelStore = append(labelStore, fmt.Sprintf("%s:%s", labelKey, labelValue))
+	}
+
+	return strings.Join(labelStore, ", ")
+}
+
+// converts value to bytes
+func ToBytes(size float64, unit string) float64 {
+	multipliers := map[string]float64{
+		"B":  1.0,
+		"KB": 1024.0,
+		"MB": 1024.0 * 1024.0,
+		"GB": 1024.0 * 1024.0 * 1024.0,
+	}
+
+	return size * multipliers[unit]
+}

--- a/pkg/utils/flags.go
+++ b/pkg/utils/flags.go
@@ -1,11 +1,37 @@
 package utils
 
-import "flag"
+import (
+	"flag"
+)
+
+type Size struct {
+	Value int64
+	Unit  string
+}
 
 type Flags struct {
 	DryRun        bool
 	RemoveStopped bool
 	VerboseMode   bool
+	SizeLimit     Size
+	B             bool
+	KB            bool
+	MB            bool
+	GB            bool
+}
+
+func (f *Flags) GetSizeUnit() string {
+	if f.B {
+		return "b"
+	} else if f.KB {
+		return "kb"
+	} else if f.MB {
+		return "mb"
+	} else if f.GB {
+		return "gb"
+	} else {
+		return ""
+	}
 }
 
 func ParseFlags() *Flags {
@@ -13,6 +39,12 @@ func ParseFlags() *Flags {
 	flag.BoolVar(&f.DryRun, "dry-run", false, "List unused Docker images without deleting them")
 	flag.BoolVar(&f.RemoveStopped, "remove-stopped", false, "Remove Images Associated with Stopped Containers")
 	flag.BoolVar(&f.VerboseMode, "verbose", false, "Verbose mode provides additional details about each image during cleanup")
+	flag.Int64Var(&f.SizeLimit.Value, "size-limit", 0, "Specify the size limit to filter images (e.g., 500MB, 1GB)")
+	flag.BoolVar(&f.B, "B", false, "Specify the size unit as bytes")
+	flag.BoolVar(&f.KB, "KB", false, "Specify the size unit as kilobytes")
+	flag.BoolVar(&f.MB, "MB", false, "Specify the size unit as megabytes")
+	flag.BoolVar(&f.GB, "GB", false, "Specify the size unit as gigabytes")
+
 	flag.Parse()
 	return f
 }

--- a/pkg/utils/flags.go
+++ b/pkg/utils/flags.go
@@ -5,12 +5,14 @@ import "flag"
 type Flags struct {
 	DryRun        bool
 	RemoveStopped bool
+	VerboseMode   bool
 }
 
 func ParseFlags() *Flags {
 	f := &Flags{}
 	flag.BoolVar(&f.DryRun, "dry-run", false, "List unused Docker images without deleting them")
 	flag.BoolVar(&f.RemoveStopped, "remove-stopped", false, "Remove Images Associated with Stopped Containers")
+	flag.BoolVar(&f.VerboseMode, "verbose", false, "Verbose mode provides additional details about each image during cleanup")
 	flag.Parse()
 	return f
 }

--- a/pkg/utils/flags.go
+++ b/pkg/utils/flags.go
@@ -5,7 +5,7 @@ import (
 )
 
 type Size struct {
-	Value int64
+	Value float64
 	Unit  string
 }
 
@@ -22,13 +22,13 @@ type Flags struct {
 
 func (f *Flags) GetSizeUnit() string {
 	if f.B {
-		return "b"
+		return "B"
 	} else if f.KB {
-		return "kb"
+		return "KB"
 	} else if f.MB {
-		return "mb"
+		return "MB"
 	} else if f.GB {
-		return "gb"
+		return "GB"
 	} else {
 		return ""
 	}
@@ -39,7 +39,7 @@ func ParseFlags() *Flags {
 	flag.BoolVar(&f.DryRun, "dry-run", false, "List unused Docker images without deleting them")
 	flag.BoolVar(&f.RemoveStopped, "remove-stopped", false, "Remove Images Associated with Stopped Containers")
 	flag.BoolVar(&f.VerboseMode, "verbose", false, "Verbose mode provides additional details about each image during cleanup")
-	flag.Int64Var(&f.SizeLimit.Value, "size-limit", 0, "Specify the size limit to filter images (e.g., 500MB, 1GB)")
+	flag.Float64Var(&f.SizeLimit.Value, "size-limit", 0, "Specify the size limit to filter images (e.g., 500MB, 1GB)")
 	flag.BoolVar(&f.B, "B", false, "Specify the size unit as bytes")
 	flag.BoolVar(&f.KB, "KB", false, "Specify the size unit as kilobytes")
 	flag.BoolVar(&f.MB, "MB", false, "Specify the size unit as megabytes")

--- a/scripts/test/generate-unused-images.ps1
+++ b/scripts/test/generate-unused-images.ps1
@@ -1,0 +1,31 @@
+# generate-unused-images.ps1
+
+# This script automates the generation of test Docker images for the Dockclean application. 
+# It creates multiple Docker images with different version labels, simulating untagged images for testing purposes.
+# The script simplifies the process of recreating test images after cleanup operations.
+# Ensure that a valid Dockerfile is present in the current directory before running the script.
+
+# Array of versions to build
+$versions = @("1.0", "2.0", "3.0", "4.0")
+
+# Initialize the index for tracking progress
+$index = 0
+
+# Build Docker images one by one
+foreach ($version in $versions) {
+    # Build Docker image with the current version label
+    docker build --no-cache --label tag="for-test" --label version="$version" .
+
+    # Display build completion message
+    Write-Host "`n---------------------------------------------------------`n"
+    Write-Host "Build complete for Docker image version: $version" -ForegroundColor Green
+    Write-Host "`n---------------------------------------------------------`n"
+
+    # Check if there are more versions to build
+    if ($index -lt ($versions.Length - 1)) {
+        Write-Host "Starting to build the next Docker image ...`n" -ForegroundColor Green
+    }
+
+    # Increment the index
+    $index++
+}

--- a/scripts/test/generate-unused-images.sh
+++ b/scripts/test/generate-unused-images.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# generate-unused-images.sh
+
+# This script automates the generation of test Docker images for the Dockclean application.
+# It creates multiple Docker images with different version labels, simulating untagged images for testing purposes.
+# The script simplifies the process of recreating test images after cleanup operations.
+# Ensure that a valid Dockerfile is present in the current directory before running the script.
+
+# Array of versions to build
+versions=("1.0" "2.0" "3.0" "4.0")
+
+# Build Docker images one by one
+for i in "${!versions[@]}"; do
+    version=${versions[$i]}
+    
+    # Build Docker image with the current version label
+    docker build --no-cache --label tag="for-test" --label version="$version" .
+
+    # Display build completion message
+    echo -e "\n---------------------------------------------------------"
+    echo -e "Build complete for Docker image version: $version"
+    echo -e "---------------------------------------------------------\n"
+
+    # Check if there are more versions to build
+    if [ $i -lt $((${#versions[@]} - 1)) ]; then
+        echo "Starting to build the next Docker image ..."
+    fi
+done


### PR DESCRIPTION
Here's a revised version of your PR description:

---

### PR Description

- [x] **Main Feature:** Implemented `RemoveExceedSizeLimit()` to address the image size threshold for clearing unused images.
- [x] **Code Refactor 01:** Replaced `log.Fatalf` with `log.Printf` to improve error handling by returning errors to `main.go`. Additionally, added `utils.go` in the Docker package to consolidate reusable functions.
- [x] **Code Refactor 02:** Removed all `fmt` package usages and switched to the Go `log` library for logging.

### Testing

![dockclean-sizelimit](https://github.com/user-attachments/assets/35a8c5fe-4851-4aae-ae92-75e354820b4e)

--- 

Let me know if you need any more adjustments!