### PR TITLE
Completed Feature: Parallel Image Deletion (Issue : #6)

### DIFF
--- a/cmd/cleaner/main.go
+++ b/cmd/cleaner/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/mmuazam98/dockclean/internal/docker"
@@ -32,7 +33,15 @@ func main() {
 		}
 		dc.RemoveExceedSizeLimit(f.SizeLimit.Value, unit)
 	default:
-		dc.RemoveUnusedImages()
+		var exectionTime string
+		if f.ConcurrentDelete {
+			exectionTime = docker.MeasureExecutionTime(func() { dc.RemoveUnusedImages(true) })
+			fmt.Println("Execution Time ( Concurrent ) : ", exectionTime)
+		} else {
+			exectionTime = docker.MeasureExecutionTime(func() { dc.RemoveUnusedImages(false) })
+			fmt.Println("Execution Time ( Sequential ) : ", exectionTime)
+		}
+
 	}
 
 }

--- a/internal/docker/containers.go
+++ b/internal/docker/containers.go
@@ -63,7 +63,7 @@ func (d *DockerClient) CleanupStoppedContainerImages() error {
 
 	for imageId, removalState := range imagesForCleanup {
 		if removalState == ImageStateExited {
-			_, err := d.CLI.ImageRemove(context.Background(), imageId, opts)
+			err := RemoveDockerImage(d, context.Background(), imageId, opts)
 			if err != nil {
 				log.Printf("Failed to remove image %s: %v", imageId, err)
 			} else {

--- a/internal/docker/images.go
+++ b/internal/docker/images.go
@@ -82,7 +82,7 @@ func (d *DockerClient) VerboseModeCleanup() error {
 	// Iterate over each unused image and attempt removal
 	for _, image := range images {
 		// Remove the image
-		_, err := d.CLI.ImageRemove(context.Background(), image.ID, opts)
+		err := RemoveDockerImage(d, context.Background(), image.ID, opts)
 		if err != nil {
 			log.Printf("Failed to remove image %s: %v\n", image.ID, err)
 		} else {
@@ -128,7 +128,7 @@ func (d *DockerClient) RemoveExceedSizeLimit(sizeLimit float64, unit string) err
 
 		// checking and removing images exceeding the threshold size
 		if image.Size > sizeLimitInBytes {
-			_, err := d.CLI.ImageRemove(context.Background(), image.ID, opts)
+			err := RemoveDockerImage(d, context.Background(), image.ID, opts)
 			if err != nil {
 				log.Printf("Failed to remove image %s: %v", image.ID, err)
 			} else {
@@ -162,7 +162,7 @@ func (d *DockerClient) RemoveUnusedImages() error {
 	opts := image.RemoveOptions{Force: true}
 
 	for _, image := range images {
-		_, err := d.CLI.ImageRemove(context.Background(), image.ID, opts)
+		err := RemoveDockerImage(d, context.Background(), image.ID, opts)
 		if err != nil {
 			log.Printf("Failed to remove image %s: %v", image.ID, err)
 		} else {
@@ -171,4 +171,10 @@ func (d *DockerClient) RemoveUnusedImages() error {
 	}
 
 	return nil
+}
+
+// RemoveDockerImage
+func RemoveDockerImage(d *DockerClient, ctx context.Context, imageID string, opts image.RemoveOptions) error {
+	_, err := d.CLI.ImageRemove(context.Background(), imageID, opts)
+	return err
 }

--- a/internal/docker/images.go
+++ b/internal/docker/images.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/docker/docker/api/types/image"
@@ -151,7 +152,7 @@ func (d *DockerClient) RemoveExceedSizeLimit(sizeLimit float64, unit string) err
 }
 
 // RemoveUnusedImages deletes unused Docker images
-func (d *DockerClient) RemoveUnusedImages() error {
+func (d *DockerClient) RemoveUnusedImages(concurrent bool) error {
 
 	images, err := d.ListUnusedImages()
 	if err != nil {
@@ -160,21 +161,77 @@ func (d *DockerClient) RemoveUnusedImages() error {
 	}
 
 	opts := image.RemoveOptions{Force: true}
+	ctx := context.Background()
 
-	for _, image := range images {
-		err := RemoveDockerImage(d, context.Background(), image.ID, opts)
+	if concurrent {
+
+		err := removeImagesConcurrent(d, images, opts, ctx)
 		if err != nil {
-			log.Printf("Failed to remove image %s: %v", image.ID, err)
+			log.Printf("Error removing the docker images concurrently : %v", err)
+			return err
 		} else {
-			log.Printf("Successfully removed image %s", image.ID)
+			log.Printf("Successfully removed all the docker images")
+		}
+
+	} else {
+
+		err := removeImagesSequential(d, images, opts, ctx)
+		if err != nil {
+			log.Printf("Error removing the docker images : %v", err)
+			return err
+		} else {
+			log.Printf("Successfully removed all the docker images")
 		}
 	}
 
 	return nil
 }
 
-// RemoveDockerImage
-func RemoveDockerImage(d *DockerClient, ctx context.Context, imageID string, opts image.RemoveOptions) error {
-	_, err := d.CLI.ImageRemove(context.Background(), imageID, opts)
-	return err
+// concurrent delete docker images
+func removeImagesConcurrent(d *DockerClient, images []image.Summary, opts image.RemoveOptions, ctx context.Context) error {
+	var wg sync.WaitGroup
+	errChan := make(chan error, len(images))
+
+	for _, image := range images {
+		wg.Add(1)
+		go handleConcurrentImageDeletion(d, ctx, image.ID, opts, &wg, errChan)
+	}
+
+	wg.Wait()
+	close(errChan)
+
+	for err := range errChan {
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// sequential delete docker images
+func removeImagesSequential(d *DockerClient, images []image.Summary, opts image.RemoveOptions, ctx context.Context) error {
+
+	for _, image := range images {
+		err := RemoveDockerImage(d, ctx, image.ID, opts)
+		if err != nil {
+			log.Printf("Failed to remove image %s: %v", image.ID, err)
+			return err
+		} else {
+			log.Printf("Successfully removed image %s", image.ID)
+		}
+	}
+
+	return nil
+
+}
+
+// handle single image during concurrent deletion
+func handleConcurrentImageDeletion(d *DockerClient, ctx context.Context, imageID string, opts image.RemoveOptions, wg *sync.WaitGroup, errChan chan<- error) {
+	defer wg.Done()
+	if err := RemoveDockerImage(d, ctx, imageID, opts); err != nil {
+		errChan <- fmt.Errorf("failed to delete image %s : %w", imageID, err)
+	} else {
+		log.Printf("Successfully removed image %s", imageID)
+	}
 }

--- a/internal/docker/utils.go
+++ b/internal/docker/utils.go
@@ -1,8 +1,12 @@
 package docker
 
 import (
+	"context"
 	"fmt"
 	"strings"
+	"time"
+
+	"github.com/docker/docker/api/types/image"
 )
 
 // Helper function to truncate docker image ID with ellipsis
@@ -56,4 +60,18 @@ func ToBytes(size float64, unit string) float64 {
 	}
 
 	return size * multipliers[unit]
+}
+
+// RemoveDockerImage
+func RemoveDockerImage(d *DockerClient, ctx context.Context, imageID string, opts image.RemoveOptions) error {
+	_, err := d.CLI.ImageRemove(context.Background(), imageID, opts)
+	return err
+}
+
+// Measure Execution Time
+func MeasureExecutionTime(f func()) string {
+	startTime := time.Now()
+	f()
+	duration := time.Since(startTime)
+	return duration.String()
 }

--- a/pkg/utils/flags.go
+++ b/pkg/utils/flags.go
@@ -10,14 +10,15 @@ type Size struct {
 }
 
 type Flags struct {
-	DryRun        bool
-	RemoveStopped bool
-	VerboseMode   bool
-	SizeLimit     Size
-	B             bool
-	KB            bool
-	MB            bool
-	GB            bool
+	DryRun           bool
+	RemoveStopped    bool
+	VerboseMode      bool
+	SizeLimit        Size
+	B                bool
+	KB               bool
+	MB               bool
+	GB               bool
+	ConcurrentDelete bool
 }
 
 func (f *Flags) GetSizeUnit() string {
@@ -44,6 +45,7 @@ func ParseFlags() *Flags {
 	flag.BoolVar(&f.KB, "KB", false, "Specify the size unit as kilobytes")
 	flag.BoolVar(&f.MB, "MB", false, "Specify the size unit as megabytes")
 	flag.BoolVar(&f.GB, "GB", false, "Specify the size unit as gigabytes")
+	flag.BoolVar(&f.ConcurrentDelete, "concurrent", false, "Enable concurrent deletion of Docker images using Go routines")
 
 	flag.Parse()
 	return f

--- a/pkg/utils/flags.go
+++ b/pkg/utils/flags.go
@@ -39,7 +39,7 @@ func ParseFlags() *Flags {
 	flag.BoolVar(&f.DryRun, "dry-run", false, "List unused Docker images without deleting them")
 	flag.BoolVar(&f.RemoveStopped, "remove-stopped", false, "Remove Images Associated with Stopped Containers")
 	flag.BoolVar(&f.VerboseMode, "verbose", false, "Verbose mode provides additional details about each image during cleanup")
-	flag.Float64Var(&f.SizeLimit.Value, "size-limit", 0, "Specify the size limit to filter images (e.g., 500MB, 1GB)")
+	flag.Float64Var(&f.SizeLimit.Value, "size-limit", -1, "Specify the size limit to filter images (e.g., 500MB, 1GB)")
 	flag.BoolVar(&f.B, "B", false, "Specify the size unit as bytes")
 	flag.BoolVar(&f.KB, "KB", false, "Specify the size unit as kilobytes")
 	flag.BoolVar(&f.MB, "MB", false, "Specify the size unit as megabytes")

--- a/scripts/test/generate-bulk-unused-images.ps1
+++ b/scripts/test/generate-bulk-unused-images.ps1
@@ -1,0 +1,31 @@
+# generate-unused-images.ps1
+
+# This script automates the generation of test Docker images for the Dockclean application. 
+# It creates multiple Docker images with different version labels, simulating untagged images for testing purposes.
+# The script simplifies the process of recreating test images after cleanup operations.
+# Ensure that a valid Dockerfile is present in the current directory before running the script.
+
+# Array of versions to build
+$versions = @("1.0", "2.0", "3.0", "4.0","5.0", "6.0", "7.0", "8.0","9.0", "10.0", "11.0", "12.0")
+
+# Initialize the index for tracking progress
+$index = 0
+
+# Build Docker images one by one
+foreach ($version in $versions) {
+    # Build Docker image with the current version label
+    docker build --no-cache --label tag="for-test" --label version="$version" .
+
+    # Display build completion message
+    Write-Host "`n---------------------------------------------------------`n"
+    Write-Host "Build complete for Docker image version: $version" -ForegroundColor Green
+    Write-Host "`n---------------------------------------------------------`n"
+
+    # Check if there are more versions to build
+    if ($index -lt ($versions.Length - 1)) {
+        Write-Host "Starting to build the next Docker image ...`n" -ForegroundColor Green
+    }
+
+    # Increment the index
+    $index++
+}


### PR DESCRIPTION
### PR Description

- [x] **Feature**: Added `removeImagesConcurrent()` for concurrent Docker image deletion, enhancing cleanup speed.
- [x] **Refactor**: Extracted reusable image removal function and added `MeasureExecutionTime(f func())` to compare sequential vs. concurrent performance.

### Execution Time Comparison

- **Sequential**: 611 ms  
  ![Sequential Execution](https://github.com/user-attachments/assets/68eadf90-6171-45cc-891d-d57302ebf7aa)
  
- **Concurrent**: 143 ms  
  ![Concurrent Execution](https://github.com/user-attachments/assets/0f6bb59d-1d51-4d37-ada9-81dc8601eefb)